### PR TITLE
*: change org and rename default branch

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: ["main","master"]
+    branches: ["main"]
 
 jobs:
   main:
@@ -32,7 +32,7 @@ jobs:
         with:
           push: true
           platforms: linux/arm64, linux/arm, linux/amd64
-          tags: heptoprint/adjacency:latest, heptoprint/adjacency:${{ steps.sha.outputs.sha }}
+          tags: kiloio/adjacency:latest, kiloio/adjacency:${{ steps.sha.outputs.sha }}
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Adjacency creates an adjacency matrix for an SRV record to check the latencies b
 It can generate a square (n x n) matrix from all (n) nodes where the service is runnning.
 Alternatively, if an SRV record for a different service that runs on m nodes is specified at query-time, it will produce a n x m matrix of latencies from nodes to service endpoints. 
 
-![Build Status](https://github.com/heptoprint/adjacency/workflows/ci/badge.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/heptoprint/adjacency)](https://goreportcard.com/report/github.com/heptoprint/adjacency)
+![Build Status](https://github.com/kilo-io/adjacency/workflows/ci/badge.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kilo-io/adjacency)](https://goreportcard.com/report/github.com/kilo-io/adjacency)
 
 ## Getting Started
 
 Run the adjacency service and specify an SRV record that resolves to all the endpoints where the service is running:
 
 ```shell
-docker run --rm -p 3000:3000 heptoprint/adjacency --srv _service._tcp.exmaple.com
+docker run --rm -p 3000:3000 kiloio/adjacency --srv _service._tcp.exmaple.com
 ```
 
 Do this for all nodes.
@@ -42,7 +42,7 @@ curl example.com:3000?format=json
 Apply the adjacency service to a Kubernetes cluster with
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/heptoprint/adjacency/master/example.yaml
+kubectl apply -f https://raw.githubusercontent.com/kilo-io/adjacency/main/example.yaml
 ```
 
 ## API

--- a/example.yaml
+++ b/example.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: adjacency
-        image: heptoprint/adjacency
+        image: kiloio/adjacency
         args: 
         - --listen-address=:8080
         - --srv=_http._tcp.adjacency

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heptoprint/adjacency_service
+module github.com/kilo-io/adjacency_service
 
 go 1.14
 


### PR DESCRIPTION
This commit changes the GitHub organization to `kilo-io`, the Docker Hub
organization to `kiloio` (Docker Hub does not allow `-` in names), and
renames the default branch to `main`

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>