### PR TITLE
main.go: add prober

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,7 +214,6 @@ func timeHTTPRequest(ctx context.Context, probers []prober.Prober, u *url.URL) *
 	if err != nil {
 		log.Printf("failed to successfully determine any latency: %v\n", err)
 		errorCounter.Inc()
-		return &Latency{Duration: dur, Host: u.Hostname(), Destination: u.String(), Prober: p.String()}
 	}
 	// Try to get IP address of target
 	// Shadow the err, because not being able to get an IP address should not
@@ -227,9 +226,10 @@ func timeHTTPRequest(ctx context.Context, probers []prober.Prober, u *url.URL) *
 	return &Latency{
 		Destination: u.String(),
 		Duration:    dur,
+		Host:        u.Hostname(),
+		Prober:      p.String(),
 		IP:          ip,
 		Ok:          err == nil,
-		Prober:      p.String(),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kilo-io/adjacency_service/pkg/prober"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -68,6 +70,7 @@ type Latency struct {
 	Host        string        `json:"host,omitempty"`
 	Duration    time.Duration `json:"duration"`
 	Ok          bool          `json:"ok"`
+	Prober      string        `json:"prober"`
 }
 
 type Vector struct {
@@ -197,28 +200,21 @@ func (m matrix) String(f format) string {
 	return tableString.String()
 }
 
-func timeHTTPRequest(ctx context.Context, u *url.URL) *Latency {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		log.Printf("failed to create Request: %v\n", err)
-		errorCounter.Inc()
-		return &Latency{Host: u.Hostname(), Destination: u.String()}
-	}
-	start := time.Now()
+func timeHTTPRequest(ctx context.Context, probers []prober.Prober, u *url.URL) *Latency {
 	var dur time.Duration
-	var res *http.Response
-	if res, err = httpPingClient.Do(req); err != nil {
-		log.Printf("failed to make ping request: %v\n", err)
-		// set the time to almost infinity
-		dur = time.Duration(1<<63 - 1)
-	} else {
-		dur = time.Now().Sub(start)
-		if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
-			log.Printf("failed to discard body: %v\n", err)
+	var err error
+	var p prober.Prober
+	for _, p = range probers {
+		if dur, err = p.Probe(ctx, *u); err == nil {
+			break
+		} else {
+			log.Printf("prober %s failed: %v", p.String(), err)
 		}
-		if err := res.Body.Close(); err != nil {
-			log.Printf("failed to close body: %v\n", err)
-		}
+	}
+	if err != nil {
+		log.Printf("failed to successfully determine any latency: %v\n", err)
+		errorCounter.Inc()
+		return &Latency{Duration: dur, Host: u.Hostname(), Destination: u.String(), Prober: p.String()}
 	}
 	// Try to get IP address of target
 	// Shadow the err, because not being able to get an IP address should not
@@ -233,17 +229,18 @@ func timeHTTPRequest(ctx context.Context, u *url.URL) *Latency {
 		Duration:    dur,
 		IP:          ip,
 		Ok:          err == nil,
+		Prober:      p.String(),
 	}
 }
 
-func getLatencies(ctx context.Context, urls []*url.URL) []*Latency {
+func getLatencies(ctx context.Context, probers []prober.Prober, urls []*url.URL) []*Latency {
 	var wg sync.WaitGroup
 	lats := make([]*Latency, len(urls))
 	for i := range urls {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			lats[i] = timeHTTPRequest(ctx, urls[i])
+			lats[i] = timeHTTPRequest(ctx, probers, urls[i])
 		}(i)
 	}
 	wg.Wait()
@@ -267,7 +264,7 @@ func resolveSRV(srv, path, query string) ([]*url.URL, error) {
 	return urls, nil
 }
 
-func vectorHandler(defaultSRV string) func(http.ResponseWriter, *http.Request) {
+func vectorHandler(defaultSRV string, probers []prober.Prober) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		srv := defaultSRV
 		var err error
@@ -280,14 +277,14 @@ func vectorHandler(defaultSRV string) func(http.ResponseWriter, *http.Request) {
 				return
 			}
 		}
-		urls, err := resolveSRV(srv, "/ping", "")
+		urls, err := resolveSRV(srv, "", "")
 		if err != nil {
 			log.Printf("failed to resolve SRV record: %v\n", err)
 			errorCounter.Inc()
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
-		lats := getLatencies(r.Context(), urls)
+		lats := getLatencies(r.Context(), probers, urls)
 		data, err := json.Marshal(lats)
 		if err != nil {
 			log.Printf("failed to marshal data: %v\n", err)
@@ -427,6 +424,7 @@ func main() {
 		log.Printf("%q is not a valid srv record name\n", *srv)
 		return
 	}
+	probers := []prober.Prober{prober.NewHTTPPingProber(&httpPingClient), prober.NewHTTPProber(&httpPingClient), prober.NewTCPProber(), &prober.NoProber{}}
 	r := prometheus.NewRegistry()
 	r.MustRegister(
 		errorCounter,
@@ -437,7 +435,7 @@ func main() {
 	m := http.NewServeMux()
 	mm := http.NewServeMux()
 	mm.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
-	m.HandleFunc("/vector", metricsMiddleWare("/vector", vectorHandler(*srv)))
+	m.HandleFunc("/vector", metricsMiddleWare("/vector", vectorHandler(*srv, probers)))
 	m.HandleFunc("/ping", metricsMiddleWare("/ping", pingHandler))
 	m.HandleFunc("/", metricsMiddleWare("/", collectAllHandler(*srv)))
 	go http.ListenAndServe(*metricsAddr, mm)

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -1,0 +1,152 @@
+package prober
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"syscall"
+	"time"
+)
+
+type Prober interface {
+	Probe(context.Context, url.URL) (time.Duration, error)
+	String() string
+}
+
+// The Client interface's purpose is to enable easy testing of Probers by consuming a simplified interface
+// instead of a http.Client.
+type Client interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// NoProber implements the Prober interface.
+// NoProber will always return an error and a large duration.
+type NoProber struct{}
+
+func (p *NoProber) Probe(ctx context.Context, u url.URL) (time.Duration, error) {
+	dur := time.Duration(1<<63 - 1)
+	return dur, errors.New("this is no Probe")
+}
+
+func (p *NoProber) String() string {
+	return "no-Prober"
+}
+
+// HTTPPingProber implements the Prober interface.
+type HTTPPingProber struct {
+	c Client
+}
+
+// NewHTTPPingProber returns a HTTPProber.
+// It is safe to use concurrently.
+func NewHTTPPingProber(c Client) *HTTPPingProber {
+	return &HTTPPingProber{c: c}
+}
+
+func (p *HTTPPingProber) Probe(ctx context.Context, u url.URL) (time.Duration, error) {
+	u.Path = "ping"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+	start := time.Now()
+	var dur time.Duration
+	var res *http.Response
+	if res, err = p.c.Do(req); err != nil {
+		return 0, fmt.Errorf("failed to make request to %s: %w", u.String(), err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("expected status Code 200, got %d", res.StatusCode)
+	}
+	dur = time.Now().Sub(start)
+	if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
+		log.Printf("failed to discard body: %v\n", err)
+	}
+	if err := res.Body.Close(); err != nil {
+		log.Printf("failed to close body: %v\n", err)
+	}
+	return dur, nil
+}
+
+func (p *HTTPPingProber) String() string {
+	return "http-ping-prober"
+}
+
+// HTTPProber implements the Prober interface.
+type HTTPProber struct {
+	c Client
+}
+
+// NewHTTPProber returns a HTTPProber.
+// It is safe to use concurrently.
+func NewHTTPProber(c Client) *HTTPProber {
+	return &HTTPProber{c: c}
+}
+
+func (p *HTTPProber) Probe(ctx context.Context, u url.URL) (time.Duration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+	start := time.Now()
+	var dur time.Duration
+	var res *http.Response
+	if res, err = p.c.Do(req); err != nil {
+		return 0, fmt.Errorf("failed to make request to %s: %w", u.String(), err)
+	}
+	dur = time.Now().Sub(start)
+	if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
+		log.Printf("failed to discard body: %v\n", err)
+	}
+	if err := res.Body.Close(); err != nil {
+		log.Printf("failed to close body: %v\n", err)
+	}
+	return dur, nil
+}
+
+func (p *HTTPProber) String() string {
+	return "http-prober"
+}
+
+// TCPProber implements the Prober interface.
+type TCPProber struct {
+	dialer net.Dialer
+}
+
+// NewTCPProber returns a new TCPProber.
+// It is safe to use it concurrently because
+// it only contains a net.Dialer.
+func NewTCPProber() *TCPProber {
+	return &TCPProber{
+		dialer: net.Dialer{},
+	}
+}
+
+// TCPProber tries to establish a TCP connection to the host and port of the given URL.
+// If TCPProber receives an ECONNRESET, it will return no error and use the time between the initial
+// attempt to establish the connection and the reception of the TCP RST signal.
+func (p TCPProber) Probe(ctx context.Context, u url.URL) (dur time.Duration, err error) {
+	start := time.Now()
+	var conn net.Conn
+	sysErr := &os.SyscallError{}
+	if conn, err = p.dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", u.Hostname(), u.Port())); err == nil {
+		defer conn.Close()
+	} else if errors.As(err, &sysErr) && sysErr.Err == syscall.ECONNRESET {
+		log.Printf("Received ECONNRESET from %s, continuing\n", u.String())
+	} else {
+		return 0, fmt.Errorf("failed to establish a TCP connection with %s: %w", fmt.Sprintf("%s:%s", u.Hostname(), u.Port()), err)
+	}
+	dur = time.Now().Sub(start)
+	return dur, nil
+}
+
+func (p TCPProber) String() string {
+	return "tcp-prober"
+}

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -32,11 +32,11 @@ type NoProber struct{}
 
 func (p *NoProber) Probe(ctx context.Context, u url.URL) (time.Duration, error) {
 	dur := time.Duration(1<<63 - 1)
-	return dur, errors.New("this is no Probe")
+	return dur, errors.New("this is no probe")
 }
 
 func (p *NoProber) String() string {
-	return "no-Prober"
+	return "no-prober"
 }
 
 // HTTPPingProber implements the Prober interface.

--- a/pkg/prober/prober_test.go
+++ b/pkg/prober/prober_test.go
@@ -1,0 +1,112 @@
+package prober
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type fakeReader struct{}
+
+func (r fakeReader) Read(b []byte) (int, error) {
+	return 0, io.EOF
+}
+
+type fakeClient struct {
+	dofunc func(req *http.Request) (*http.Response, error)
+}
+
+var okClient fakeClient = fakeClient{
+	dofunc: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Status:     "200",
+			Body:       io.NopCloser(&fakeReader{}),
+		}, nil
+	},
+}
+
+var notFoundClient fakeClient = fakeClient{
+	dofunc: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 404,
+			Status:     "404",
+			Body:       io.NopCloser(&fakeReader{}),
+		}, nil
+	},
+}
+
+var errorClient fakeClient = fakeClient{
+	dofunc: func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("some error")
+	},
+}
+
+func (c fakeClient) Do(req *http.Request) (*http.Response, error) {
+	time.Sleep(10000)
+	return c.dofunc(req)
+}
+
+func TestHTTPPingClient(t *testing.T) {
+	for i, tc := range []struct {
+		name string
+		err  error
+		c    Client
+	}{
+		{
+			name: "ok",
+			err:  nil,
+			c:    okClient,
+		},
+		{
+			name: "not found",
+			err:  errors.New("some error"),
+			c:    notFoundClient,
+		},
+		{
+			name: "error",
+			err:  errors.New("some error"),
+			c:    errorClient,
+		},
+	} {
+		c := NewHTTPPingProber(tc.c)
+		_, err := c.Probe(context.TODO(), url.URL{})
+		if (tc.err == nil) != (err == nil) {
+			t.Errorf("%d (%s): got = %v, expected = %v", i, tc.name, err, tc.err)
+		}
+	}
+}
+
+func TestHTTPClient(t *testing.T) {
+	for i, tc := range []struct {
+		name string
+		err  error
+		c    Client
+	}{
+		{
+			name: "ok",
+			err:  nil,
+			c:    okClient,
+		},
+		{
+			name: "not found",
+			err:  nil,
+			c:    notFoundClient,
+		},
+		{
+			name: "error",
+			err:  errors.New("some error"),
+			c:    errorClient,
+		},
+	} {
+		c := NewHTTPProber(tc.c)
+		_, err := c.Probe(context.TODO(), url.URL{})
+		if (tc.err == nil) != (err == nil) {
+			t.Errorf("%d (%s): got = %v, expected = %v", i, tc.name, err, tc.err)
+		}
+	}
+}


### PR DESCRIPTION
Instead of hitting one http endpoint, adjacency will
 - hit the http ping endpoint at /ping
 - hit the http endpoint at /
 - try to establish a tcp connection
 - use a large duration time as latency
If any of the above is successful, the following methods are not
executed.

This should solve #9 and partly #5. Partly because srv records that use anything but tcp will still not work. However, I am not sure how to measure a latency with a udp "connection".