### PR TITLE
main.go: use context to cancel on timeout and improve output

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -33,7 +33,6 @@ func TestPad(t *testing.T) {
 		IP:          "10.0.0.4",
 	}
 	ld := Latency{
-		Ok:          true,
 		Destination: "dummy",
 	}
 	v1 := Vector{
@@ -125,7 +124,6 @@ func TestPad(t *testing.T) {
 					Latencies: []Latency{
 						{
 							Destination: "dummy",
-							Ok:          true,
 						},
 						{
 							Destination: "2",
@@ -154,7 +152,6 @@ func TestPad(t *testing.T) {
 						},
 						{
 							Destination: "dummy",
-							Ok:          true,
 						},
 						{
 							Destination: "3",
@@ -163,7 +160,6 @@ func TestPad(t *testing.T) {
 						},
 						{
 							Destination: "dummy",
-							Ok:          true,
 						},
 					},
 				},


### PR DESCRIPTION
This commit uses context to cancel requests after a timeout that can be
set with flags. It also simplifies the output by removing the
code=[false|true]. False will be displayed with "-" and latencies that
were never probed e.g. one instance was unreachable the fields will
contain empty string "".

Sorry for putting this in one PR.