### PR TITLE
docs: use GHCR image in example.yaml

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: adjacency
-        image: kiloio/adjacency
+        image: ghcr.io/kilo-io/adjacency
         args: 
         - --listen-address=:8080
         - --srv=_http._tcp.adjacency


### PR DESCRIPTION
This will help users of the example.yaml, e.g. Kilo e2e tests, not hit rate limits.